### PR TITLE
Update get_pos.py

### DIFF
--- a/Latin/get_pos.py
+++ b/Latin/get_pos.py
@@ -42,6 +42,6 @@ for entry in tree.findall('entry'):
 
 
 with open('content_pos.json', 'w') as file:
-    json.dump(result, file, indent=2)
+    json.dump(result, file, indent=2, ensure_ascii=False)
 
 print(resultcount)


### PR DESCRIPTION
Solve the encoding in the JSON files for strings like "abaliēnātio, -ōnis" (currently encoded as: `abali\u0113n\u0101tio, -\u014dnis`).

The fix is to add `ensure_ascii=False` to the `json.dump`.